### PR TITLE
Build for Python 3.8 & Pin to Versions of sagelib

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,16 +8,52 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      linux_64_python3.6.____cpython:
-        CONFIG: linux_64_python3.6.____cpython
+      linux_64_python3.6.____cpythonsagelib8.9:
+        CONFIG: linux_64_python3.6.____cpythonsagelib8.9
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
-      linux_64_python3.7.____cpython:
-        CONFIG: linux_64_python3.7.____cpython
+      linux_64_python3.6.____cpythonsagelib9.0:
+        CONFIG: linux_64_python3.6.____cpythonsagelib9.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
-      linux_64_python3.8.____cpython:
-        CONFIG: linux_64_python3.8.____cpython
+      linux_64_python3.6.____cpythonsagelib9.1:
+        CONFIG: linux_64_python3.6.____cpythonsagelib9.1
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.6.____cpythonsagelib9.2:
+        CONFIG: linux_64_python3.6.____cpythonsagelib9.2
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.7.____cpythonsagelib8.9:
+        CONFIG: linux_64_python3.7.____cpythonsagelib8.9
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.7.____cpythonsagelib9.0:
+        CONFIG: linux_64_python3.7.____cpythonsagelib9.0
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.7.____cpythonsagelib9.1:
+        CONFIG: linux_64_python3.7.____cpythonsagelib9.1
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.7.____cpythonsagelib9.2:
+        CONFIG: linux_64_python3.7.____cpythonsagelib9.2
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.8.____cpythonsagelib8.9:
+        CONFIG: linux_64_python3.8.____cpythonsagelib8.9
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.8.____cpythonsagelib9.0:
+        CONFIG: linux_64_python3.8.____cpythonsagelib9.0
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.8.____cpythonsagelib9.1:
+        CONFIG: linux_64_python3.8.____cpythonsagelib9.1
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.8.____cpythonsagelib9.2:
+        CONFIG: linux_64_python3.8.____cpythonsagelib9.2
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,6 +8,10 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
+      linux_64_python3.6.____cpythonsagelib8.8:
+        CONFIG: linux_64_python3.6.____cpythonsagelib8.8
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_python3.6.____cpythonsagelib8.9:
         CONFIG: linux_64_python3.6.____cpythonsagelib8.9
         UPLOAD_PACKAGES: 'True'
@@ -24,6 +28,10 @@ jobs:
         CONFIG: linux_64_python3.6.____cpythonsagelib9.2
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.7.____cpythonsagelib8.8:
+        CONFIG: linux_64_python3.7.____cpythonsagelib8.8
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_python3.7.____cpythonsagelib8.9:
         CONFIG: linux_64_python3.7.____cpythonsagelib8.9
         UPLOAD_PACKAGES: 'True'
@@ -38,6 +46,10 @@ jobs:
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_python3.7.____cpythonsagelib9.2:
         CONFIG: linux_64_python3.7.____cpythonsagelib9.2
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.8.____cpythonsagelib8.8:
+        CONFIG: linux_64_python3.8.____cpythonsagelib8.8
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_python3.8.____cpythonsagelib8.9:

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,6 +16,10 @@ jobs:
         CONFIG: linux_64_python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.8.____cpython:
+        CONFIG: linux_64_python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -14,6 +14,9 @@ jobs:
       osx_64_python3.7.____cpython:
         CONFIG: osx_64_python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
+      osx_64_python3.8.____cpython:
+        CONFIG: osx_64_python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,6 +8,9 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
+      osx_64_python3.6.____cpythonsagelib8.8:
+        CONFIG: osx_64_python3.6.____cpythonsagelib8.8
+        UPLOAD_PACKAGES: 'True'
       osx_64_python3.6.____cpythonsagelib8.9:
         CONFIG: osx_64_python3.6.____cpythonsagelib8.9
         UPLOAD_PACKAGES: 'True'
@@ -20,6 +23,9 @@ jobs:
       osx_64_python3.6.____cpythonsagelib9.2:
         CONFIG: osx_64_python3.6.____cpythonsagelib9.2
         UPLOAD_PACKAGES: 'True'
+      osx_64_python3.7.____cpythonsagelib8.8:
+        CONFIG: osx_64_python3.7.____cpythonsagelib8.8
+        UPLOAD_PACKAGES: 'True'
       osx_64_python3.7.____cpythonsagelib8.9:
         CONFIG: osx_64_python3.7.____cpythonsagelib8.9
         UPLOAD_PACKAGES: 'True'
@@ -31,6 +37,9 @@ jobs:
         UPLOAD_PACKAGES: 'True'
       osx_64_python3.7.____cpythonsagelib9.2:
         CONFIG: osx_64_python3.7.____cpythonsagelib9.2
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.8.____cpythonsagelib8.8:
+        CONFIG: osx_64_python3.8.____cpythonsagelib8.8
         UPLOAD_PACKAGES: 'True'
       osx_64_python3.8.____cpythonsagelib8.9:
         CONFIG: osx_64_python3.8.____cpythonsagelib8.9

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,14 +8,41 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_python3.6.____cpython:
-        CONFIG: osx_64_python3.6.____cpython
+      osx_64_python3.6.____cpythonsagelib8.9:
+        CONFIG: osx_64_python3.6.____cpythonsagelib8.9
         UPLOAD_PACKAGES: 'True'
-      osx_64_python3.7.____cpython:
-        CONFIG: osx_64_python3.7.____cpython
+      osx_64_python3.6.____cpythonsagelib9.0:
+        CONFIG: osx_64_python3.6.____cpythonsagelib9.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_python3.8.____cpython:
-        CONFIG: osx_64_python3.8.____cpython
+      osx_64_python3.6.____cpythonsagelib9.1:
+        CONFIG: osx_64_python3.6.____cpythonsagelib9.1
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.6.____cpythonsagelib9.2:
+        CONFIG: osx_64_python3.6.____cpythonsagelib9.2
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.7.____cpythonsagelib8.9:
+        CONFIG: osx_64_python3.7.____cpythonsagelib8.9
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.7.____cpythonsagelib9.0:
+        CONFIG: osx_64_python3.7.____cpythonsagelib9.0
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.7.____cpythonsagelib9.1:
+        CONFIG: osx_64_python3.7.____cpythonsagelib9.1
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.7.____cpythonsagelib9.2:
+        CONFIG: osx_64_python3.7.____cpythonsagelib9.2
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.8.____cpythonsagelib8.9:
+        CONFIG: osx_64_python3.8.____cpythonsagelib8.9
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.8.____cpythonsagelib9.0:
+        CONFIG: osx_64_python3.8.____cpythonsagelib9.0
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.8.____cpythonsagelib9.1:
+        CONFIG: osx_64_python3.8.____cpythonsagelib9.1
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.8.____cpythonsagelib9.2:
+        CONFIG: osx_64_python3.8.____cpythonsagelib9.2
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_64_python3.6.____cpythonsagelib8.8.yaml
+++ b/.ci_support/linux_64_python3.6.____cpythonsagelib8.8.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+gmp:
+- '6'
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+sagelib:
+- '8.8'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.6.____cpythonsagelib8.9.yaml
+++ b/.ci_support/linux_64_python3.6.____cpythonsagelib8.9.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+gmp:
+- '6'
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+sagelib:
+- '8.9'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.6.____cpythonsagelib9.0.yaml
+++ b/.ci_support/linux_64_python3.6.____cpythonsagelib9.0.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+gmp:
+- '6'
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+sagelib:
+- '9.0'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.6.____cpythonsagelib9.1.yaml
+++ b/.ci_support/linux_64_python3.6.____cpythonsagelib9.1.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+gmp:
+- '6'
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+sagelib:
+- '9.1'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.6.____cpythonsagelib9.2.yaml
+++ b/.ci_support/linux_64_python3.6.____cpythonsagelib9.2.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+gmp:
+- '6'
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+sagelib:
+- '9.2'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.7.____cpythonsagelib8.8.yaml
+++ b/.ci_support/linux_64_python3.7.____cpythonsagelib8.8.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+gmp:
+- '6'
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+sagelib:
+- '8.8'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.7.____cpythonsagelib8.9.yaml
+++ b/.ci_support/linux_64_python3.7.____cpythonsagelib8.9.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+gmp:
+- '6'
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+sagelib:
+- '8.9'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.7.____cpythonsagelib9.0.yaml
+++ b/.ci_support/linux_64_python3.7.____cpythonsagelib9.0.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+gmp:
+- '6'
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+sagelib:
+- '9.0'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.7.____cpythonsagelib9.1.yaml
+++ b/.ci_support/linux_64_python3.7.____cpythonsagelib9.1.yaml
@@ -1,21 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
 gmp:
 - '6'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   gmp:
     max_pin: x
@@ -24,8 +24,12 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+sagelib:
+- '9.1'
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.7.____cpythonsagelib9.2.yaml
+++ b/.ci_support/linux_64_python3.7.____cpythonsagelib9.2.yaml
@@ -24,6 +24,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+sagelib:
+- '9.2'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -1,0 +1,33 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+gmp:
+- '6'
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.8.____cpythonsagelib8.8.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonsagelib8.8.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+gmp:
+- '6'
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+sagelib:
+- '8.8'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.8.____cpythonsagelib8.9.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonsagelib8.9.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+gmp:
+- '6'
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+sagelib:
+- '8.9'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.8.____cpythonsagelib9.0.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonsagelib9.0.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+gmp:
+- '6'
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+sagelib:
+- '9.0'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.8.____cpythonsagelib9.1.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonsagelib9.1.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+gmp:
+- '6'
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+sagelib:
+- '9.1'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.8.____cpythonsagelib9.2.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonsagelib9.2.yaml
@@ -23,7 +23,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.6.* *_cpython
+- 3.8.* *_cpython
+sagelib:
+- '9.2'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/osx_64_python3.6.____cpythonsagelib8.8.yaml
+++ b/.ci_support/osx_64_python3.6.____cpythonsagelib8.8.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+sagelib:
+- '8.8'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.6.____cpythonsagelib8.9.yaml
+++ b/.ci_support/osx_64_python3.6.____cpythonsagelib8.9.yaml
@@ -24,6 +24,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.6.* *_cpython
+sagelib:
+- '8.9'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.6.____cpythonsagelib9.0.yaml
+++ b/.ci_support/osx_64_python3.6.____cpythonsagelib9.0.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+sagelib:
+- '9.0'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.6.____cpythonsagelib9.1.yaml
+++ b/.ci_support/osx_64_python3.6.____cpythonsagelib9.1.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+sagelib:
+- '9.1'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.6.____cpythonsagelib9.2.yaml
+++ b/.ci_support/osx_64_python3.6.____cpythonsagelib9.2.yaml
@@ -23,7 +23,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.6.* *_cpython
+sagelib:
+- '9.2'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.7.____cpythonsagelib8.8.yaml
+++ b/.ci_support/osx_64_python3.7.____cpythonsagelib8.8.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+sagelib:
+- '8.8'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.7.____cpythonsagelib8.9.yaml
+++ b/.ci_support/osx_64_python3.7.____cpythonsagelib8.9.yaml
@@ -1,21 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '9'
-cdt_name:
-- cos6
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '9'
-docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- '11'
 gmp:
 - '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   gmp:
     max_pin: x
@@ -23,11 +23,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.7.* *_cpython
+sagelib:
+- '8.9'
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image

--- a/.ci_support/osx_64_python3.7.____cpythonsagelib9.0.yaml
+++ b/.ci_support/osx_64_python3.7.____cpythonsagelib9.0.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+sagelib:
+- '9.0'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.7.____cpythonsagelib9.1.yaml
+++ b/.ci_support/osx_64_python3.7.____cpythonsagelib9.1.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+sagelib:
+- '9.1'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.7.____cpythonsagelib9.2.yaml
+++ b/.ci_support/osx_64_python3.7.____cpythonsagelib9.2.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+sagelib:
+- '9.2'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.8.____cpythonsagelib8.8.yaml
+++ b/.ci_support/osx_64_python3.8.____cpythonsagelib8.8.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+sagelib:
+- '8.8'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.8.____cpythonsagelib8.9.yaml
+++ b/.ci_support/osx_64_python3.8.____cpythonsagelib8.9.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+sagelib:
+- '8.9'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.8.____cpythonsagelib9.0.yaml
+++ b/.ci_support/osx_64_python3.8.____cpythonsagelib9.0.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+sagelib:
+- '9.0'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.8.____cpythonsagelib9.1.yaml
+++ b/.ci_support/osx_64_python3.8.____cpythonsagelib9.1.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+sagelib:
+- '9.1'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_python3.8.____cpythonsagelib9.2.yaml
+++ b/.ci_support/osx_64_python3.8.____cpythonsagelib9.2.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+sagelib:
+- '9.2'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -10,9 +10,10 @@ export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
 source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
 
 
-endgroup "Start Docker"
+( endgroup "Start Docker" ) 2> /dev/null
 
-startgroup "Configuring conda"
+( startgroup "Configuring conda" ) 2> /dev/null
+
 export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
@@ -36,34 +37,38 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-endgroup "Configuring conda"
+
+( endgroup "Configuring conda" ) 2> /dev/null
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    startgroup "Running conda debug"
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
     fi
     conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-    endgroup "Running conda debug"
+
     # Drop into an interactive shell
     /bin/bash
 else
-    startgroup "Running conda $BUILD_CMD"
     conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-    endgroup "Running conda build"
-    startgroup "Validating outputs"
+    ( startgroup "Validating outputs" ) 2> /dev/null
+
     validate_recipe_outputs "${FEEDSTOCK_NAME}"
-    endgroup "Validating outputs"
+
+    ( endgroup "Validating outputs" ) 2> /dev/null
+
+    ( startgroup "Uploading packages" ) 2> /dev/null
 
     if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-        startgroup "Uploading packages"
         upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
-        endgroup "Uploading packages"
     fi
+
+    ( endgroup "Uploading packages" ) 2> /dev/null
 fi
+
+( startgroup "Final checks" ) 2> /dev/null
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -13,18 +13,23 @@ function startgroup {
         travis )
             echo "$1"
             echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        github_actions )
+            echo "::group::$1";;
         * )
             echo "$1";;
     esac
-}
+} 2> /dev/null
 
 function endgroup {
     # End a foldable group of log lines
     # Pass a single argument, quoted
+
     case ${CI:-} in
         azure )
             echo "##[endgroup]";;
         travis )
             echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+        github_actions )
+            echo "::endgroup::";;
     esac
-}
+} 2> /dev/null

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -7,7 +7,7 @@
 
 source .scripts/logging_utils.sh
 
-startgroup "Configure Docker"
+( startgroup "Configure Docker" ) 2> /dev/null
 
 set -xeo pipefail
 
@@ -69,9 +69,11 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
-endgroup "Configure Docker"
 
-startgroup "Start Docker"
+( endgroup "Configure Docker" ) 2> /dev/null
+
+( startgroup "Start Docker" ) 2> /dev/null
+
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
@@ -95,3 +97,6 @@ docker run ${DOCKER_RUN_ARGS} \
 
 # verify that the end of the script was reached
 test -f "$DONE_CANARY"
+
+# This closes the last group opened in `build_steps.sh`
+( endgroup "Final checks" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -2,16 +2,19 @@
 
 source .scripts/logging_utils.sh
 
-set -x
+set -xe
 
-startgroup "Installing a fresh version of Miniforge"
+( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
+
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
 MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
 bash $MINIFORGE_FILE -b
-endgroup "Installing a fresh version of Miniforge"
 
-startgroup "Configuring conda"
+( endgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
+
+( startgroup "Configuring conda" ) 2> /dev/null
+
 BUILD_CMD=build
 
 source ${HOME}/miniforge3/etc/profile.d/conda.sh
@@ -34,22 +37,24 @@ echo -e "\n\nRunning the build setup script."
 source run_conda_forge_build_setup
 
 
-endgroup "Configuring conda"
 
-set -e
+( endgroup "Configuring conda" ) 2> /dev/null
 
-startgroup "Running conda $BUILD_CMD"
+
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
 conda $BUILD_CMD ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
-endgroup "Running conda build"
-startgroup "Validating outputs"
+( startgroup "Validating outputs" ) 2> /dev/null
+
 validate_recipe_outputs "${FEEDSTOCK_NAME}"
-endgroup "Validating outputs"
+
+( endgroup "Validating outputs" ) 2> /dev/null
+
+( startgroup "Uploading packages" ) 2> /dev/null
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-  startgroup "Uploading packages"
   upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
-  endgroup "Uploading packages"
 fi
+
+( endgroup "Uploading packages" ) 2> /dev/null

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
+              <td>linux_64_python3.6.____cpythonsagelib8.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.6.____cpythonsagelib8.8" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_python3.6.____cpythonsagelib8.9</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
@@ -61,6 +68,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.6.____cpythonsagelib9.2" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_python3.7.____cpythonsagelib8.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.7.____cpythonsagelib8.8" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -92,6 +106,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_python3.8.____cpythonsagelib8.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpythonsagelib8.8" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_python3.8.____cpythonsagelib8.9</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
@@ -117,6 +138,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpythonsagelib9.2" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.6.____cpythonsagelib8.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.6.____cpythonsagelib8.8" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -148,6 +176,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_64_python3.7.____cpythonsagelib8.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7.____cpythonsagelib8.8" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_python3.7.____cpythonsagelib8.9</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
@@ -173,6 +208,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7.____cpythonsagelib9.2" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.8.____cpythonsagelib8.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.8.____cpythonsagelib8.8" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/README.md
+++ b/README.md
@@ -36,45 +36,171 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_python3.6.____cpython</td>
+              <td>linux_64_python3.6.____cpythonsagelib8.9</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.6.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.6.____cpythonsagelib8.9" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_python3.7.____cpython</td>
+              <td>linux_64_python3.6.____cpythonsagelib9.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.6.____cpythonsagelib9.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_python3.8.____cpython</td>
+              <td>linux_64_python3.6.____cpythonsagelib9.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.6.____cpythonsagelib9.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.6.____cpython</td>
+              <td>linux_64_python3.6.____cpythonsagelib9.2</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.6.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.6.____cpythonsagelib9.2" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.7.____cpython</td>
+              <td>linux_64_python3.7.____cpythonsagelib8.9</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.7.____cpythonsagelib8.9" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.8.____cpython</td>
+              <td>linux_64_python3.7.____cpythonsagelib9.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.7.____cpythonsagelib9.0" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_python3.7.____cpythonsagelib9.1</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.7.____cpythonsagelib9.1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_python3.7.____cpythonsagelib9.2</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.7.____cpythonsagelib9.2" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_python3.8.____cpythonsagelib8.9</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpythonsagelib8.9" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_python3.8.____cpythonsagelib9.0</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpythonsagelib9.0" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_python3.8.____cpythonsagelib9.1</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpythonsagelib9.1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_python3.8.____cpythonsagelib9.2</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpythonsagelib9.2" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.6.____cpythonsagelib8.9</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.6.____cpythonsagelib8.9" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.6.____cpythonsagelib9.0</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.6.____cpythonsagelib9.0" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.6.____cpythonsagelib9.1</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.6.____cpythonsagelib9.1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.6.____cpythonsagelib9.2</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.6.____cpythonsagelib9.2" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.7.____cpythonsagelib8.9</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7.____cpythonsagelib8.9" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.7.____cpythonsagelib9.0</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7.____cpythonsagelib9.0" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.7.____cpythonsagelib9.1</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7.____cpythonsagelib9.1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.7.____cpythonsagelib9.2</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7.____cpythonsagelib9.2" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.8.____cpythonsagelib8.9</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.8.____cpythonsagelib8.9" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.8.____cpythonsagelib9.0</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.8.____cpythonsagelib9.0" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.8.____cpythonsagelib9.1</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.8.____cpythonsagelib9.1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.8.____cpythonsagelib9.2</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.8.____cpythonsagelib9.2" alt="variant">
                 </a>
               </td>
             </tr>

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
@@ -61,6 +68,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7279&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/surface-dynamics-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr>
@@ -85,6 +99,7 @@ Installing `surface-dynamics` from the `conda-forge` channel can be achieved by 
 
 ```
 conda config --add channels conda-forge
+conda config --set channel_priority strict
 ```
 
 Once the `conda-forge` channel has been enabled, `surface-dynamics` can be installed with:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,9 @@
+# Since we build with Cython against the SageMath API/ABI, we need to build
+# separately for different versions of SageMath. In fact, there is a breaking
+# change in 9.2 (ModuleElementWithMutability) but we have not checked the other
+# versions so there might be more than than.
+sagelib:
+  - 8.9
+  - 9.0
+  - 9.1
+  - 9.2

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,6 +3,7 @@
 # change in 9.2 (ModuleElementWithMutability) but we have not checked the other
 # versions so there might be more than than.
 sagelib:
+  - 8.8
   - 8.9
   - 9.0
   - 9.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,13 +23,13 @@ requirements:
   host:
     - python
     - pip
-    - sagelib
+    - sagelib {{ sagelib }}
     # surface_dynamics.interval_exchanges.iet_family links against ppl and gmp
     - ppl
     - gmp
   run:
     - python
-    - sagelib
+    - sagelib {{ sagelib }}
     # LattE Integrale is recommended, but it is not packaged yet: https://github.com/conda-forge/staged-recipes/pull/8959
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ build:
   number: 1
   # SageMath is not packaged for Windows
   skip: true  # [win]
+  # SageMath <= 9.1 is not built for Python >= 3.8 on conda-forge
+  skip: true  # [py>=38 and sagelib!='9.2']
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,9 @@ source:
   sha256: f72d7576590a95396112d6a4e44e682adfab2d5562600d7fb2c7151ab1fab88d
 
 build:
-  number: 0
+  number: 1
   # SageMath is not packaged for Windows
   skip: true  # [win]
-  # SageMath is not packaged for Python 3.8 yet
-  skip: true  # [py>=38]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:


### PR DESCRIPTION
Since surface-dynamics builds against the Sagelib API/ABI with Cython, we need to pin the SageMath version that was used when building the Cython code.